### PR TITLE
remove /saml security-constraint. Not needed with 1.9

### DIFF
--- a/app-profile-jee-saml/src/main/webapp/WEB-INF/web.xml
+++ b/app-profile-jee-saml/src/main/webapp/WEB-INF/web.xml
@@ -31,15 +31,6 @@
         </auth-constraint>
     </security-constraint>
 
-    <security-constraint>
-        <web-resource-collection>
-            <url-pattern>/saml</url-pattern>
-        </web-resource-collection>
-        <auth-constraint>
-            <role-name>*</role-name>
-        </auth-constraint>
-    </security-constraint>
-
     <login-config>
         <auth-method>KEYCLOAK-SAML</auth-method>
     </login-config>


### PR DESCRIPTION
remove /saml security-constraint. Not needed with 1.9